### PR TITLE
Enable Customization of Package Name

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,14 @@ multiplatformSwiftPackage {
 }
 ```
 
+### Framework Name
+By default, the plugin will create a package with the same name as the project itself.
+You can configure the name of the generated package by providing your own framework name.
+
+```kotlin
+frameworkName(FrameworkName("MySwiftFramework"))
+```
+
 ### Output Directory
 By default, the plugin will write all files into the _swiftpackage_ folder in the project directory.
 You can configure the output folder by providing a File object pointing to it.

--- a/README.md
+++ b/README.md
@@ -48,13 +48,18 @@ multiplatformSwiftPackage {
 }
 ```
 
-### Framework Name
-By default, the plugin will create a package with the same name as the project itself.
-You can configure the name of the generated package by providing your own framework name.
+### Package Name
+By default, the name of the Swift package will be the base name of the first framework found in the project.
+However, you can declare a different name for the package.
+This might be useful if your frameworks have different base names, and you want your package to have a common name.
 
 ```kotlin
-frameworkName(FrameworkName("MySwiftFramework"))
+packageName("MyAwesomeKit")
 ```
+
+Hint:
+If the cocoapods plugin is applied the name of the package will default to the value assigned to the `frameworkName` property.
+Otherwise, the value of the `baseName` property of the framework configuration will be used.
 
 ### Output Directory
 By default, the plugin will write all files into the _swiftpackage_ folder in the project directory.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,6 +17,7 @@ dependencies {
     testImplementation("io.kotest:kotest-assertions-core:4.3.0")
     testImplementation("io.kotest:kotest-property:4.3.0")
     testImplementation("io.mockk:mockk:1.10.0")
+    testImplementation(kotlin("gradle-plugin"))
 }
 
 java {

--- a/src/main/kotlin/com/chromaticnoise/multiplatformswiftpackage/SwiftPackageExtension.kt
+++ b/src/main/kotlin/com/chromaticnoise/multiplatformswiftpackage/SwiftPackageExtension.kt
@@ -12,7 +12,7 @@ import java.io.File
 public open class SwiftPackageExtension(project: Project) {
 
     internal var buildConfiguration: BuildConfiguration = BuildConfiguration.Release
-    internal var frameworkName: FrameworkName = FrameworkName(project.name)
+    internal var packageName: Either<PluginConfigurationError, PackageName>? = null
     internal var outputDirectory: OutputDirectory = OutputDirectory(File(project.projectDir, "swiftpackage"))
     internal var swiftToolsVersion: SwiftToolVersion? = null
     internal var distributionMode: DistributionMode = DistributionMode.Local
@@ -20,13 +20,13 @@ public open class SwiftPackageExtension(project: Project) {
     internal var appleTargets: Collection<AppleTarget> = emptyList()
 
     /**
-     * Sets the name of the framework to be built.
-     * Defaults to ${project.name}
+     * Sets the name of the Swift package.
+     * Defaults to the base name of the first framework found in the project.
      *
-     * @param name of the framework to generate.
+     * @param name of the Swift package.
      */
-    public fun frameworkName(name: String) {
-        frameworkName = FrameworkName(name)
+    public fun packageName(name: String) {
+        packageName = PackageName.of(name)
     }
 
     /**

--- a/src/main/kotlin/com/chromaticnoise/multiplatformswiftpackage/SwiftPackageExtension.kt
+++ b/src/main/kotlin/com/chromaticnoise/multiplatformswiftpackage/SwiftPackageExtension.kt
@@ -12,11 +12,22 @@ import java.io.File
 public open class SwiftPackageExtension(project: Project) {
 
     internal var buildConfiguration: BuildConfiguration = BuildConfiguration.Release
+    internal var frameworkName: FrameworkName = FrameworkName(project.name)
     internal var outputDirectory: OutputDirectory = OutputDirectory(File(project.projectDir, "swiftpackage"))
     internal var swiftToolsVersion: SwiftToolVersion? = null
     internal var distributionMode: DistributionMode = DistributionMode.Local
     internal var targetPlatforms: Collection<Either<List<PluginConfigurationError>, TargetPlatform>> = emptyList()
     internal var appleTargets: Collection<AppleTarget> = emptyList()
+
+    /**
+     * Sets the name of the framework to be built.
+     * Defaults to ${project.name}
+     *
+     * @param name of the framework to generate.
+     */
+    public fun frameworkName(name: String) {
+        frameworkName = FrameworkName(name)
+    }
 
     /**
      * Sets the directory where files like the Package.swift and XCFramework will be created.

--- a/src/main/kotlin/com/chromaticnoise/multiplatformswiftpackage/domain/Either.kt
+++ b/src/main/kotlin/com/chromaticnoise/multiplatformswiftpackage/domain/Either.kt
@@ -4,6 +4,10 @@ internal sealed class Either<out L, out R> {
     data class Left<out L, out R>(val value: L) : Either<L, R>()
     data class Right<out L, out R>(val value: R) : Either<L, R>()
 
+    val leftValueOrNull: L? get() = (this as? Left)?.value
+
+    val orNull: R? get() = (this as? Right)?.value
+
     fun <T> fold(l: (L) -> T, r: (R) -> T): T = when (this) {
         is Left -> l(value)
         is Right -> r(value)

--- a/src/main/kotlin/com/chromaticnoise/multiplatformswiftpackage/domain/FrameworkName.kt
+++ b/src/main/kotlin/com/chromaticnoise/multiplatformswiftpackage/domain/FrameworkName.kt
@@ -1,3 +1,0 @@
-package com.chromaticnoise.multiplatformswiftpackage.domain
-
-internal data class FrameworkName(val value: String)

--- a/src/main/kotlin/com/chromaticnoise/multiplatformswiftpackage/domain/FrameworkName.kt
+++ b/src/main/kotlin/com/chromaticnoise/multiplatformswiftpackage/domain/FrameworkName.kt
@@ -1,0 +1,3 @@
+package com.chromaticnoise.multiplatformswiftpackage.domain
+
+internal data class FrameworkName(val value: String)

--- a/src/main/kotlin/com/chromaticnoise/multiplatformswiftpackage/domain/PackageName.kt
+++ b/src/main/kotlin/com/chromaticnoise/multiplatformswiftpackage/domain/PackageName.kt
@@ -1,0 +1,19 @@
+package com.chromaticnoise.multiplatformswiftpackage.domain
+
+import com.chromaticnoise.multiplatformswiftpackage.domain.PluginConfiguration.PluginConfigurationError
+import com.chromaticnoise.multiplatformswiftpackage.domain.PluginConfiguration.PluginConfigurationError.InvalidPackageName
+
+internal class PackageName private constructor(val value: String) {
+
+    internal companion object {
+        fun of(name: String?): Either<PluginConfigurationError, PackageName> =
+            name?.ifNotBlank { Either.Right(PackageName(it)) }
+            ?: Either.Left(InvalidPackageName(name))
+    }
+
+    override fun equals(other: Any?): Boolean = value == (other as? PackageName)?.value
+
+    override fun hashCode(): Int = value.hashCode()
+
+    override fun toString(): String = "PackageName(value='$value')"
+}

--- a/src/main/kotlin/com/chromaticnoise/multiplatformswiftpackage/domain/PluginConfiguration.kt
+++ b/src/main/kotlin/com/chromaticnoise/multiplatformswiftpackage/domain/PluginConfiguration.kt
@@ -5,6 +5,7 @@ import com.chromaticnoise.multiplatformswiftpackage.domain.PluginConfiguration.P
 
 internal class PluginConfiguration private constructor(
     val buildConfiguration: BuildConfiguration,
+    val frameworkName: FrameworkName,
     val outputDirectory: OutputDirectory,
     val swiftToolsVersion: SwiftToolVersion,
     val distributionMode: DistributionMode,
@@ -38,6 +39,7 @@ internal class PluginConfiguration private constructor(
                 Either.Right(
                     PluginConfiguration(
                         extension.buildConfiguration,
+                        extension.frameworkName,
                         extension.outputDirectory,
                         extension.swiftToolsVersion!!,
                         extension.distributionMode,

--- a/src/main/kotlin/com/chromaticnoise/multiplatformswiftpackage/domain/Project+PluginConfiguration.kt
+++ b/src/main/kotlin/com/chromaticnoise/multiplatformswiftpackage/domain/Project+PluginConfiguration.kt
@@ -33,5 +33,9 @@ private fun List<PluginConfigurationError>.toErrorMessage() = joinToString("\n\n
         * Target name is invalid: ${error.name}
           Only the following target names are valid: ${TargetName.values().joinToString { it.identifier }}
         """.trimIndent()
+        is PluginConfigurationError.InvalidPackageName -> """
+        * Package name is invalid: ${error.name}
+          Either declare the base name of your frameworks or use a non-empty package name.
+        """.trimIndent()
     }
 }

--- a/src/main/kotlin/com/chromaticnoise/multiplatformswiftpackage/domain/SwiftPackageConfiguration.kt
+++ b/src/main/kotlin/com/chromaticnoise/multiplatformswiftpackage/domain/SwiftPackageConfiguration.kt
@@ -6,6 +6,7 @@ import org.gradle.api.Project
 
 internal data class SwiftPackageConfiguration(
     private val project: Project,
+    private val frameworkName: FrameworkName,
     private val toolVersion: SwiftToolVersion,
     private val platforms: String,
     private val distributionMode: DistributionMode,
@@ -19,7 +20,7 @@ internal data class SwiftPackageConfiguration(
 
     internal val templateProperties = mapOf(
         "toolsVersion" to toolVersion.name,
-        "name" to project.name,
+        "name" to frameworkName.value,
         "platforms" to platforms,
         "isLocal" to (distributionMode == DistributionMode.Local),
         "url" to distributionUrl?.value,

--- a/src/main/kotlin/com/chromaticnoise/multiplatformswiftpackage/domain/SwiftPackageConfiguration.kt
+++ b/src/main/kotlin/com/chromaticnoise/multiplatformswiftpackage/domain/SwiftPackageConfiguration.kt
@@ -6,7 +6,7 @@ import org.gradle.api.Project
 
 internal data class SwiftPackageConfiguration(
     private val project: Project,
-    private val frameworkName: FrameworkName,
+    private val packageName: PackageName,
     private val toolVersion: SwiftToolVersion,
     private val platforms: String,
     private val distributionMode: DistributionMode,
@@ -15,12 +15,12 @@ internal data class SwiftPackageConfiguration(
 
     private val distributionUrl = when (distributionMode) {
         DistributionMode.Local -> null
-        is DistributionMode.Remote -> distributionMode.url.appendPath(zipFileName(project))
+        is DistributionMode.Remote -> distributionMode.url.appendPath(zipFileName(project, packageName))
     }
 
     internal val templateProperties = mapOf(
         "toolsVersion" to toolVersion.name,
-        "name" to frameworkName.value,
+        "name" to packageName.value,
         "platforms" to platforms,
         "isLocal" to (distributionMode == DistributionMode.Local),
         "url" to distributionUrl?.value,

--- a/src/main/kotlin/com/chromaticnoise/multiplatformswiftpackage/domain/extensions.kt
+++ b/src/main/kotlin/com/chromaticnoise/multiplatformswiftpackage/domain/extensions.kt
@@ -1,6 +1,7 @@
 package com.chromaticnoise.multiplatformswiftpackage.domain
 
 import org.gradle.api.Action
+import org.jetbrains.kotlin.gradle.plugin.mpp.Framework
 import org.jetbrains.kotlin.konan.target.Family
 import org.jetbrains.kotlin.konan.target.KonanTarget
 
@@ -34,3 +35,8 @@ internal val TargetName.konanTarget: KonanTarget get() = when (this) {
     TargetName.TvOSx64 -> KonanTarget.TVOS_X64
     TargetName.MacOSx64 -> KonanTarget.MACOS_X64
 }
+
+internal fun Collection<AppleTarget>.getFrameworks(buildConfiguration: BuildConfiguration): Collection<Framework> =
+    mapNotNull { target ->
+        target.framework(buildConfiguration)
+    }

--- a/src/main/kotlin/com/chromaticnoise/multiplatformswiftpackage/task/CreateSwiftPackageTask.kt
+++ b/src/main/kotlin/com/chromaticnoise/multiplatformswiftpackage/task/CreateSwiftPackageTask.kt
@@ -22,11 +22,11 @@ internal fun Project.registerCreateSwiftPackageTask() {
 
             val packageConfiguration = SwiftPackageConfiguration(
                 project = project,
-                frameworkName = configuration.frameworkName,
+                packageName = configuration.packageName,
                 toolVersion = configuration.swiftToolsVersion,
                 platforms = platforms(configuration),
                 distributionMode = configuration.distributionMode,
-                zipChecksum = zipFileChecksum(project, configuration.outputDirectory)
+                zipChecksum = zipFileChecksum(project, configuration.outputDirectory, configuration.packageName)
             )
 
             SimpleTemplateEngine()

--- a/src/main/kotlin/com/chromaticnoise/multiplatformswiftpackage/task/CreateSwiftPackageTask.kt
+++ b/src/main/kotlin/com/chromaticnoise/multiplatformswiftpackage/task/CreateSwiftPackageTask.kt
@@ -22,6 +22,7 @@ internal fun Project.registerCreateSwiftPackageTask() {
 
             val packageConfiguration = SwiftPackageConfiguration(
                 project = project,
+                frameworkName = configuration.frameworkName,
                 toolVersion = configuration.swiftToolsVersion,
                 platforms = platforms(configuration),
                 distributionMode = configuration.distributionMode,

--- a/src/main/kotlin/com/chromaticnoise/multiplatformswiftpackage/task/CreateXCFrameworkTask.kt
+++ b/src/main/kotlin/com/chromaticnoise/multiplatformswiftpackage/task/CreateXCFrameworkTask.kt
@@ -1,6 +1,7 @@
 package com.chromaticnoise.multiplatformswiftpackage.task
 
 import com.chromaticnoise.multiplatformswiftpackage.domain.getConfigurationOrThrow
+import com.chromaticnoise.multiplatformswiftpackage.domain.getFrameworks
 import org.gradle.api.Project
 import org.gradle.api.tasks.Exec
 import java.io.File
@@ -10,12 +11,8 @@ internal fun Project.registerCreateXCFrameworkTask() = tasks.register("createXCF
     description = "Creates an XCFramework for all declared Apple targets"
 
     val configuration = getConfigurationOrThrow()
-    val buildConfiguration = configuration.buildConfiguration
-    val xcFrameworkDestination = File(configuration.outputDirectory.value, "${configuration.frameworkName}.xcframework")
-
-    val frameworks = configuration.appleTargets.mapNotNull { target ->
-        target.framework(buildConfiguration)
-    }
+    val xcFrameworkDestination = File(configuration.outputDirectory.value, "${configuration.packageName.value}.xcframework")
+    val frameworks = configuration.appleTargets.getFrameworks(configuration.buildConfiguration)
 
     dependsOn(frameworks.map { it.linkTaskName })
 
@@ -28,7 +25,7 @@ internal fun Project.registerCreateXCFrameworkTask() = tasks.register("createXCF
             add("-framework")
             add(framework.outputFile.path)
 
-            val dsymFile = File(framework.outputFile.parent, "${configuration.frameworkName}.framework.dSYM")
+            val dsymFile = File(framework.outputFile.parent, "${framework.baseName}.framework.dSYM")
             if (dsymFile.exists()) {
                 add("-debug-symbols")
                 add(dsymFile.path)

--- a/src/main/kotlin/com/chromaticnoise/multiplatformswiftpackage/task/CreateXCFrameworkTask.kt
+++ b/src/main/kotlin/com/chromaticnoise/multiplatformswiftpackage/task/CreateXCFrameworkTask.kt
@@ -11,7 +11,7 @@ internal fun Project.registerCreateXCFrameworkTask() = tasks.register("createXCF
 
     val configuration = getConfigurationOrThrow()
     val buildConfiguration = configuration.buildConfiguration
-    val xcFrameworkDestination = File(configuration.outputDirectory.value, "${project.name}.xcframework")
+    val xcFrameworkDestination = File(configuration.outputDirectory.value, "${configuration.frameworkName}.xcframework")
 
     val frameworks = configuration.appleTargets.mapNotNull { target ->
         target.framework(buildConfiguration)
@@ -28,7 +28,7 @@ internal fun Project.registerCreateXCFrameworkTask() = tasks.register("createXCF
             add("-framework")
             add(framework.outputFile.path)
 
-            val dsymFile = File(framework.outputFile.parent, "${project.name}.framework.dSYM")
+            val dsymFile = File(framework.outputFile.parent, "${configuration.frameworkName}.framework.dSYM")
             if (dsymFile.exists()) {
                 add("-debug-symbols")
                 add(dsymFile.path)

--- a/src/main/kotlin/com/chromaticnoise/multiplatformswiftpackage/task/CreateZipFileTask.kt
+++ b/src/main/kotlin/com/chromaticnoise/multiplatformswiftpackage/task/CreateZipFileTask.kt
@@ -13,7 +13,7 @@ internal fun Project.registerCreateZipFileTask() {
 
         val configuration = getConfigurationOrThrow()
         val outputDirectory = configuration.outputDirectory.value
-        archiveFileName.set(zipFileName(project))
+        archiveFileName.set(zipFileName(project,  configuration.frameworkName))
         destinationDirectory.set(outputDirectory)
         from(outputDirectory) {
             include("**/*.xcframework/")

--- a/src/main/kotlin/com/chromaticnoise/multiplatformswiftpackage/task/CreateZipFileTask.kt
+++ b/src/main/kotlin/com/chromaticnoise/multiplatformswiftpackage/task/CreateZipFileTask.kt
@@ -13,7 +13,7 @@ internal fun Project.registerCreateZipFileTask() {
 
         val configuration = getConfigurationOrThrow()
         val outputDirectory = configuration.outputDirectory.value
-        archiveFileName.set(zipFileName(project,  configuration.frameworkName))
+        archiveFileName.set(zipFileName(project, configuration.packageName))
         destinationDirectory.set(outputDirectory)
         from(outputDirectory) {
             include("**/*.xcframework/")

--- a/src/main/kotlin/com/chromaticnoise/multiplatformswiftpackage/task/zip-functions.kt
+++ b/src/main/kotlin/com/chromaticnoise/multiplatformswiftpackage/task/zip-functions.kt
@@ -1,13 +1,14 @@
 package com.chromaticnoise.multiplatformswiftpackage.task
 
+import com.chromaticnoise.multiplatformswiftpackage.domain.FrameworkName
 import com.chromaticnoise.multiplatformswiftpackage.domain.OutputDirectory
 import org.gradle.api.Project
 import java.io.ByteArrayOutputStream
 import java.io.File
 
-internal fun zipFileChecksum(project: Project, outputDirectory: OutputDirectory): String {
+internal fun zipFileChecksum(project: Project, outputDirectory: OutputDirectory, frameworkName: FrameworkName? = null): String {
     val outputPath = outputDirectory.value
-    return File(outputPath, zipFileName(project))
+    return File(outputPath, zipFileName(project, frameworkName))
         .takeIf { it.exists() }
         ?.let { zipFile ->
             ByteArrayOutputStream().use { os ->
@@ -22,4 +23,4 @@ internal fun zipFileChecksum(project: Project, outputDirectory: OutputDirectory)
         } ?: ""
 }
 
-internal fun zipFileName(project: Project) = "${project.name}-${project.version}.zip"
+internal fun zipFileName(project: Project, frameworkName: FrameworkName? = null) = "${frameworkName?.value ?: project.name}-${project.version}.zip"

--- a/src/main/kotlin/com/chromaticnoise/multiplatformswiftpackage/task/zip-functions.kt
+++ b/src/main/kotlin/com/chromaticnoise/multiplatformswiftpackage/task/zip-functions.kt
@@ -1,14 +1,14 @@
 package com.chromaticnoise.multiplatformswiftpackage.task
 
-import com.chromaticnoise.multiplatformswiftpackage.domain.FrameworkName
+import com.chromaticnoise.multiplatformswiftpackage.domain.PackageName
 import com.chromaticnoise.multiplatformswiftpackage.domain.OutputDirectory
 import org.gradle.api.Project
 import java.io.ByteArrayOutputStream
 import java.io.File
 
-internal fun zipFileChecksum(project: Project, outputDirectory: OutputDirectory, frameworkName: FrameworkName? = null): String {
+internal fun zipFileChecksum(project: Project, outputDirectory: OutputDirectory, packageName: PackageName): String {
     val outputPath = outputDirectory.value
-    return File(outputPath, zipFileName(project, frameworkName))
+    return File(outputPath, zipFileName(project, packageName))
         .takeIf { it.exists() }
         ?.let { zipFile ->
             ByteArrayOutputStream().use { os ->
@@ -23,4 +23,4 @@ internal fun zipFileChecksum(project: Project, outputDirectory: OutputDirectory,
         } ?: ""
 }
 
-internal fun zipFileName(project: Project, frameworkName: FrameworkName? = null) = "${frameworkName?.value ?: project.name}-${project.version}.zip"
+internal fun zipFileName(project: Project, packageName: PackageName) = "${packageName.value}-${project.version}.zip"

--- a/src/test/kotlin/com/chromaticnoise/multiplatformswiftpackage/domain/PackageNameTest.kt
+++ b/src/test/kotlin/com/chromaticnoise/multiplatformswiftpackage/domain/PackageNameTest.kt
@@ -1,0 +1,34 @@
+package com.chromaticnoise.multiplatformswiftpackage.domain
+
+import com.chromaticnoise.multiplatformswiftpackage.domain.PluginConfiguration.PluginConfigurationError.InvalidPackageName
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.filter
+import io.kotest.property.arbitrary.string
+import io.kotest.property.forAll
+
+class PackageNameTest : StringSpec({
+
+    "empty name should not be valid" {
+        PackageName.of("").leftValueOrNull!!.shouldBeInstanceOf<InvalidPackageName>()
+    }
+
+    "blank names should not be valid" {
+        forAll(Arb.string().filter { it.isBlank() }) { name ->
+            PackageName.of(name).leftValueOrNull is InvalidPackageName
+        }
+    }
+
+    "two instances should be equal if their names are equal" {
+        (PackageName.of("equal name") == PackageName.of("equal name"))
+            .shouldBeTrue()
+    }
+
+    "two instances should not be equal if their names differ" {
+        (PackageName.of("some name") == PackageName.of("different name"))
+            .shouldBeFalse()
+    }
+})

--- a/src/test/kotlin/com/chromaticnoise/multiplatformswiftpackage/domain/SwiftPackageConfigurationTest.kt
+++ b/src/test/kotlin/com/chromaticnoise/multiplatformswiftpackage/domain/SwiftPackageConfigurationTest.kt
@@ -5,7 +5,6 @@ import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldEndWith
 import io.kotest.matchers.string.shouldStartWith
-import io.mockk.every
 import io.mockk.mockk
 
 class SwiftPackageConfigurationTest : StringSpec() {
@@ -17,10 +16,10 @@ class SwiftPackageConfigurationTest : StringSpec() {
                 .templateProperties["toolsVersion"].shouldBe("42")
         }
 
-        "name property should match the project name" {
+        "name property should match the configured package name" {
             configuration()
-                .copy(project = mockk(relaxed = true) { every { name } returns "project name" })
-                .templateProperties["name"].shouldBe("project name")
+                .copy(packageName = PackageName.of("expected name").orNull!!)
+                .templateProperties["name"].shouldBe("expected name")
         }
 
         "platforms property should match the given platforms" {
@@ -68,7 +67,7 @@ class SwiftPackageConfigurationTest : StringSpec() {
 
     private fun configuration() = SwiftPackageConfiguration(
         project = mockk(relaxed = true),
-        frameworkName = FrameworkName("project name"),
+        packageName = PackageName.of("package name").orNull!!,
         toolVersion = SwiftToolVersion.of("42")!!,
         platforms = "",
         distributionMode = DistributionMode.Local,

--- a/src/test/kotlin/com/chromaticnoise/multiplatformswiftpackage/domain/SwiftPackageConfigurationTest.kt
+++ b/src/test/kotlin/com/chromaticnoise/multiplatformswiftpackage/domain/SwiftPackageConfigurationTest.kt
@@ -68,6 +68,7 @@ class SwiftPackageConfigurationTest : StringSpec() {
 
     private fun configuration() = SwiftPackageConfiguration(
         project = mockk(relaxed = true),
+        frameworkName = FrameworkName("project name"),
         toolVersion = SwiftToolVersion.of("42")!!,
         platforms = "",
         distributionMode = DistributionMode.Local,


### PR DESCRIPTION
First of all, _great_ work on this plugin! I expect it will grow in popularity as SPM and XCFrameworks become more ubiquitous in the coming months.

This PR proposes to add an interface to allow the customization of the `frameworkName`. The result offers similar functionality to the KMP cocoapods plugin (which also allows configuration of this property).

Because Apple-platform framework names tend not to follow the same naming conventions as their Kotlin/Java counterparts, this will help folks (such as myself) avoid:

`import my_kotlin_library`

...and instead do:

`import MyKotlinLibrary`

Let me know what you think, and thanks again for making this library!