### PR TITLE
Declare custom Package.swift template and its properties

### DIFF
--- a/src/main/kotlin/com/chromaticnoise/multiplatformswiftpackage/SwiftPackageExtension.kt
+++ b/src/main/kotlin/com/chromaticnoise/multiplatformswiftpackage/SwiftPackageExtension.kt
@@ -2,8 +2,10 @@ package com.chromaticnoise.multiplatformswiftpackage
 
 import com.chromaticnoise.multiplatformswiftpackage.domain.*
 import com.chromaticnoise.multiplatformswiftpackage.domain.PluginConfiguration.PluginConfigurationError
+import com.chromaticnoise.multiplatformswiftpackage.domain.SwiftPackageTemplate.TemplateFile
 import com.chromaticnoise.multiplatformswiftpackage.dsl.BuildConfigurationDSL
 import com.chromaticnoise.multiplatformswiftpackage.dsl.DistributionModeDSL
+import com.chromaticnoise.multiplatformswiftpackage.dsl.PackageTemplateDsl
 import com.chromaticnoise.multiplatformswiftpackage.dsl.TargetPlatformDsl
 import org.gradle.api.Action
 import org.gradle.api.Project
@@ -18,6 +20,10 @@ public open class SwiftPackageExtension(project: Project) {
     internal var distributionMode: DistributionMode = DistributionMode.Local
     internal var targetPlatforms: Collection<Either<List<PluginConfigurationError>, TargetPlatform>> = emptyList()
     internal var appleTargets: Collection<AppleTarget> = emptyList()
+    internal var packageTemplate: SwiftPackageTemplate = SwiftPackageTemplate(
+        file = TemplateFile.Resource(MultiplatformSwiftPackagePlugin::class.java.getResource("/templates/Package.swift.template")),
+        properties = emptyMap()
+    )
 
     /**
      * Sets the name of the Swift package.
@@ -71,6 +77,17 @@ public open class SwiftPackageExtension(project: Project) {
     public fun targetPlatforms(builder: Action<TargetPlatformDsl>) {
         builder.build(TargetPlatformDsl()) { dsl ->
             targetPlatforms = dsl.targetPlatforms
+        }
+    }
+
+    /**
+     * Builder for the [SwiftPackageTemplate].
+     *
+     * @param path that points to the template file.
+     */
+    public fun packageTemplate(path: File, builder: Action<PackageTemplateDsl>? = null) {
+        builder?.build(PackageTemplateDsl(path)) { dsl ->
+            packageTemplate = dsl.packageTemplate
         }
     }
 }

--- a/src/main/kotlin/com/chromaticnoise/multiplatformswiftpackage/domain/PluginConfiguration.kt
+++ b/src/main/kotlin/com/chromaticnoise/multiplatformswiftpackage/domain/PluginConfiguration.kt
@@ -10,7 +10,8 @@ internal class PluginConfiguration private constructor(
     val swiftToolsVersion: SwiftToolVersion,
     val distributionMode: DistributionMode,
     val targetPlatforms: Collection<TargetPlatform>,
-    val appleTargets: Collection<AppleTarget>
+    val appleTargets: Collection<AppleTarget>,
+    val packageTemplate: SwiftPackageTemplate
 ) {
     internal companion object {
         fun of(extension: SwiftPackageExtension): Either<List<PluginConfigurationError>, PluginConfiguration> {
@@ -47,7 +48,8 @@ internal class PluginConfiguration private constructor(
                         extension.swiftToolsVersion!!,
                         extension.distributionMode,
                         targetPlatforms,
-                        extension.appleTargets
+                        extension.appleTargets,
+                        extension.packageTemplate
                     )
                 )
             } else {

--- a/src/main/kotlin/com/chromaticnoise/multiplatformswiftpackage/domain/SwiftPackageConfiguration.kt
+++ b/src/main/kotlin/com/chromaticnoise/multiplatformswiftpackage/domain/SwiftPackageConfiguration.kt
@@ -1,36 +1,46 @@
 package com.chromaticnoise.multiplatformswiftpackage.domain
 
-import com.chromaticnoise.multiplatformswiftpackage.MultiplatformSwiftPackagePlugin
+import com.chromaticnoise.multiplatformswiftpackage.domain.SwiftPackageTemplate.TemplateFile
+import com.chromaticnoise.multiplatformswiftpackage.task.zipFileChecksum
 import com.chromaticnoise.multiplatformswiftpackage.task.zipFileName
 import org.gradle.api.Project
 
 internal data class SwiftPackageConfiguration(
     private val project: Project,
+    private val packageTemplate: SwiftPackageTemplate,
+    private val toolsVersion: SwiftToolVersion,
     private val packageName: PackageName,
-    private val toolVersion: SwiftToolVersion,
-    private val platforms: String,
     private val distributionMode: DistributionMode,
-    private val zipChecksum: String
+    private val outputDirectory: OutputDirectory,
+    private val targetPlatforms: Collection<TargetPlatform>,
+    private val appleTargets: Collection<AppleTarget>
 ) {
 
-    private val distributionUrl = when (distributionMode) {
-        DistributionMode.Local -> null
-        is DistributionMode.Remote -> distributionMode.url.appendPath(zipFileName(project, packageName))
-    }
+    internal val templateFile: TemplateFile get() = packageTemplate.file
 
-    internal val templateProperties = mapOf(
-        "toolsVersion" to toolVersion.name,
+    internal val templateProperties: Map<String, Any?> get() = mutableMapOf<String, Any?>(
+        "toolsVersion" to toolsVersion.name,
         "name" to packageName.value,
         "platforms" to platforms,
         "isLocal" to (distributionMode == DistributionMode.Local),
         "url" to distributionUrl?.value,
-        "checksum" to zipChecksum.trim()
-    )
+        "checksum" to zipFileChecksum(project, outputDirectory, packageName).trim()
+    ).apply { putAll(packageTemplate.properties) }
+
+    private val distributionUrl get() = when (distributionMode) {
+        DistributionMode.Local -> null
+        is DistributionMode.Remote -> distributionMode.url.appendPath(zipFileName(project, packageName))
+    }
+
+    private val platforms: String get() = targetPlatforms.flatMap { platform ->
+        appleTargets
+            .filter { appleTarget -> platform.targets.firstOrNull { it.konanTarget == appleTarget.nativeTarget.konanTarget } != null }
+            .mapNotNull { target -> target.nativeTarget.konanTarget.family.swiftPackagePlatformName }
+            .distinct()
+            .map { platformName -> ".$platformName(.v${platform.version.name})" }
+    }.joinToString(",\n")
 
     internal companion object {
         internal const val FILE_NAME = "Package.swift"
-
-        internal val templateFile =
-            MultiplatformSwiftPackagePlugin::class.java.getResource("/templates/Package.swift.template")
     }
 }

--- a/src/main/kotlin/com/chromaticnoise/multiplatformswiftpackage/domain/SwiftPackageTemplate.kt
+++ b/src/main/kotlin/com/chromaticnoise/multiplatformswiftpackage/domain/SwiftPackageTemplate.kt
@@ -1,0 +1,14 @@
+package com.chromaticnoise.multiplatformswiftpackage.domain
+
+import java.net.URL
+
+internal data class SwiftPackageTemplate(
+    val file: TemplateFile,
+    val properties: Map<String, Any?>
+) {
+
+    internal sealed class TemplateFile {
+        data class Resource(val url: URL) : TemplateFile()
+        data class File(val value: java.io.File) : TemplateFile()
+    }
+}

--- a/src/main/kotlin/com/chromaticnoise/multiplatformswiftpackage/dsl/PackageTemplateDsl.kt
+++ b/src/main/kotlin/com/chromaticnoise/multiplatformswiftpackage/dsl/PackageTemplateDsl.kt
@@ -1,0 +1,22 @@
+package com.chromaticnoise.multiplatformswiftpackage.dsl
+
+import com.chromaticnoise.multiplatformswiftpackage.domain.SwiftPackageTemplate
+import java.io.File
+
+/**
+ * DSL to create an instance of a [SwiftPackageTemplate].
+ */
+public class PackageTemplateDsl(file: File) {
+    internal var packageTemplate: SwiftPackageTemplate = SwiftPackageTemplate(
+        file = SwiftPackageTemplate.TemplateFile.File(file),
+        properties = emptyMap()
+    )
+
+    /**
+     * The properties that will be available in the template file when it is rendered.
+     * Properties defined here will overwrite default properties with the same key.
+     */
+    public fun properties(properties: Map<String, Any?>) {
+        packageTemplate = packageTemplate.copy(properties = properties)
+    }
+}

--- a/src/test/kotlin/com/chromaticnoise/multiplatformswiftpackage/domain/SwiftPackageConfigurationTest.kt
+++ b/src/test/kotlin/com/chromaticnoise/multiplatformswiftpackage/domain/SwiftPackageConfigurationTest.kt
@@ -1,18 +1,20 @@
 package com.chromaticnoise.multiplatformswiftpackage.domain
 
+import com.chromaticnoise.multiplatformswiftpackage.domain.SwiftPackageTemplate.TemplateFile
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldEndWith
 import io.kotest.matchers.string.shouldStartWith
 import io.mockk.mockk
+import java.io.File
 
 class SwiftPackageConfigurationTest : StringSpec() {
 
     init {
         "tools version property should match the tools version name" {
             configuration()
-                .copy(toolVersion = SwiftToolVersion.of("42")!!)
+                .copy(toolsVersion = SwiftToolVersion.of("42")!!)
                 .templateProperties["toolsVersion"].shouldBe("42")
         }
 
@@ -20,12 +22,6 @@ class SwiftPackageConfigurationTest : StringSpec() {
             configuration()
                 .copy(packageName = PackageName.of("expected name").orNull!!)
                 .templateProperties["name"].shouldBe("expected name")
-        }
-
-        "platforms property should match the given platforms" {
-            configuration()
-                .copy(platforms = "my platforms")
-                .templateProperties["platforms"].shouldBe("my platforms")
         }
 
         "is-local property should be true if distribution mode is local" {
@@ -57,20 +53,16 @@ class SwiftPackageConfigurationTest : StringSpec() {
                 .copy(distributionMode = DistributionMode.Remote(DistributionURL("my url")))
                 .templateProperties["url"] as String).shouldEndWith(".zip")
         }
-
-        "checksum property should match the value of zip checksum" {
-            configuration()
-                .copy(zipChecksum = "the checksum")
-                .templateProperties["checksum"].shouldBe("the checksum")
-        }
     }
 
     private fun configuration() = SwiftPackageConfiguration(
         project = mockk(relaxed = true),
+        packageTemplate = SwiftPackageTemplate(TemplateFile.File(File("")), emptyMap()),
+        toolsVersion = SwiftToolVersion.of("42")!!,
         packageName = PackageName.of("package name").orNull!!,
-        toolVersion = SwiftToolVersion.of("42")!!,
-        platforms = "",
         distributionMode = DistributionMode.Local,
-        zipChecksum = ""
+        outputDirectory = OutputDirectory(File("")),
+        targetPlatforms = emptyList(),
+        appleTargets = emptyList()
     )
 }


### PR DESCRIPTION
### DSL Syntax
```kotlin
multiplatformSwiftPackage {
    packageTemplate(File(project.projectDir, "custom-package.template")) {
        properties(mapOf(
            "myProp" to "my custom prop",
            "name" to "overwrite default name"
        ))
    }
}
```

### TODOs
- [ ] Tests
- [ ] Throw exception if template file does not exist
- [ ] Verify that generated swift package file is valid (or at least parseable by Swift)
- [ ] Expose default keys as public enum
- [ ] Update README
- [ ] Update CHANGELOG
