### PR TITLE
Add support for Groovy DSL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 tbd
 
+## [2.0.3]
+### Added
+- The plugin DSL is now compatible with Groovy [#17](https://github.com/ge-org/multiplatform-swiftpackage/issues/17)
+
 ## [2.0.2]
 ### Fixed
 - Fix a bug where the plugin was not able to detect the frameworks for some project configurations

--- a/README.md
+++ b/README.md
@@ -132,6 +132,18 @@ targetPlatforms {
 }
 ```
 
+__Note:__
+If you are using Groovy for the build script the target names must be passed as a list.
+```groovy
+targetPlatforms {
+  // the catch-all DSL works the same in Groovy and Kotlin
+  iOS { v("13") }
+
+  // however, Groovy requires a list when the targets() DSL is used
+  targets(['macosX64']) { v('10.0') }
+}
+```
+
 Available platform shortcuts are:
 - `iOS { v("xxx") }`
 - `tvOS { v("xxx") }`

--- a/api/multiplatform-swiftpackage.api
+++ b/api/multiplatform-swiftpackage.api
@@ -7,12 +7,15 @@ public final class com/chromaticnoise/multiplatformswiftpackage/MultiplatformSwi
 
 public class com/chromaticnoise/multiplatformswiftpackage/SwiftPackageExtension {
 	public fun <init> (Lorg/gradle/api/Project;)V
-	public final fun buildConfiguration (Lorg/gradle/api/Action;)V
-	public final fun distributionMode (Lorg/gradle/api/Action;)V
+	public final fun buildConfiguration (Lgroovy/lang/Closure;)V
+	public final fun buildConfiguration (Lkotlin/jvm/functions/Function1;)V
+	public final fun distributionMode (Lgroovy/lang/Closure;)V
+	public final fun distributionMode (Lkotlin/jvm/functions/Function1;)V
 	public final fun outputDirectory (Ljava/io/File;)V
 	public final fun packageName (Ljava/lang/String;)V
 	public final fun swiftToolsVersion (Ljava/lang/String;)V
-	public final fun targetPlatforms (Lorg/gradle/api/Action;)V
+	public final fun targetPlatforms (Lgroovy/lang/Closure;)V
+	public final fun targetPlatforms (Lkotlin/jvm/functions/Function1;)V
 }
 
 public final class com/chromaticnoise/multiplatformswiftpackage/dsl/BuildConfigurationDSL {
@@ -30,11 +33,16 @@ public final class com/chromaticnoise/multiplatformswiftpackage/dsl/Distribution
 
 public final class com/chromaticnoise/multiplatformswiftpackage/dsl/TargetPlatformDsl {
 	public fun <init> ()V
-	public final fun iOS (Lorg/gradle/api/Action;)V
-	public final fun macOS (Lorg/gradle/api/Action;)V
-	public final fun targets ([Ljava/lang/String;Lorg/gradle/api/Action;)V
-	public final fun tvOS (Lorg/gradle/api/Action;)V
-	public final fun watchOS (Lorg/gradle/api/Action;)V
+	public final fun iOS (Lgroovy/lang/Closure;)V
+	public final fun iOS (Lkotlin/jvm/functions/Function1;)V
+	public final fun macOS (Lgroovy/lang/Closure;)V
+	public final fun macOS (Lkotlin/jvm/functions/Function1;)V
+	public final fun targets (Ljava/util/Collection;Lgroovy/lang/Closure;)V
+	public final fun targets ([Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
+	public final fun tvOS (Lgroovy/lang/Closure;)V
+	public final fun tvOS (Lkotlin/jvm/functions/Function1;)V
+	public final fun watchOS (Lgroovy/lang/Closure;)V
+	public final fun watchOS (Lkotlin/jvm/functions/Function1;)V
 }
 
 public final class com/chromaticnoise/multiplatformswiftpackage/dsl/TargetPlatformDsl$PlatformVersionDsl {

--- a/src/main/kotlin/com/chromaticnoise/multiplatformswiftpackage/MultiplatformSwiftPackagePlugin.kt
+++ b/src/main/kotlin/com/chromaticnoise/multiplatformswiftpackage/MultiplatformSwiftPackagePlugin.kt
@@ -7,6 +7,7 @@ import com.chromaticnoise.multiplatformswiftpackage.task.registerCreateXCFramewo
 import com.chromaticnoise.multiplatformswiftpackage.task.registerCreateZipFileTask
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.kotlin.dsl.create
 import org.gradle.kotlin.dsl.findByType
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 
@@ -16,7 +17,8 @@ import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 public class MultiplatformSwiftPackagePlugin : Plugin<Project> {
 
     override fun apply(project: Project) {
-        val extension = project.extensions.create(EXTENSION_NAME, SwiftPackageExtension::class.java, project)
+        val extension = project.extensions.create<SwiftPackageExtension>(EXTENSION_NAME, project)
+
         project.afterEvaluate {
             project.extensions.findByType<KotlinMultiplatformExtension>()?.let { kmpExtension ->
                 extension.appleTargets = AppleTarget.allOf(

--- a/src/main/kotlin/com/chromaticnoise/multiplatformswiftpackage/SwiftPackageExtension.kt
+++ b/src/main/kotlin/com/chromaticnoise/multiplatformswiftpackage/SwiftPackageExtension.kt
@@ -5,8 +5,9 @@ import com.chromaticnoise.multiplatformswiftpackage.domain.PluginConfiguration.P
 import com.chromaticnoise.multiplatformswiftpackage.dsl.BuildConfigurationDSL
 import com.chromaticnoise.multiplatformswiftpackage.dsl.DistributionModeDSL
 import com.chromaticnoise.multiplatformswiftpackage.dsl.TargetPlatformDsl
-import org.gradle.api.Action
+import groovy.lang.Closure
 import org.gradle.api.Project
+import org.gradle.util.ConfigureUtil
 import java.io.File
 
 public open class SwiftPackageExtension(project: Project) {
@@ -50,27 +51,42 @@ public open class SwiftPackageExtension(project: Project) {
     /**
      * Builder for the [BuildConfiguration].
      */
-    public fun buildConfiguration(builder: Action<BuildConfigurationDSL>) {
-        builder.build(BuildConfigurationDSL()) { dsl ->
+    public fun buildConfiguration(configure: BuildConfigurationDSL.() -> Unit) {
+        BuildConfigurationDSL().also { dsl ->
+            dsl.configure()
             buildConfiguration = dsl.buildConfiguration
         }
+    }
+
+    public fun buildConfiguration(configure: Closure<BuildConfigurationDSL>) {
+        buildConfiguration { ConfigureUtil.configure(configure, this) }
     }
 
     /**
      * Builder for the [DistributionMode].
      */
-    public fun distributionMode(builder: Action<DistributionModeDSL>) {
-        builder.build(DistributionModeDSL()) { dsl ->
+    public fun distributionMode(configure: DistributionModeDSL.() -> Unit) {
+        DistributionModeDSL().also { dsl ->
+            dsl.configure()
             distributionMode = dsl.distributionMode
         }
+    }
+
+    public fun distributionMode(configure: Closure<DistributionModeDSL>) {
+        distributionMode { ConfigureUtil.configure(configure, this) }
     }
 
     /**
      * Builder for instances of [TargetPlatform].
      */
-    public fun targetPlatforms(builder: Action<TargetPlatformDsl>) {
-        builder.build(TargetPlatformDsl()) { dsl ->
+    public fun targetPlatforms(configure: TargetPlatformDsl.() -> Unit) {
+        TargetPlatformDsl().also { dsl ->
+            dsl.configure()
             targetPlatforms = dsl.targetPlatforms
         }
+    }
+
+    public fun targetPlatforms(configure: Closure<TargetPlatformDsl>) {
+        targetPlatforms { ConfigureUtil.configure(configure, this) }
     }
 }

--- a/src/main/kotlin/com/chromaticnoise/multiplatformswiftpackage/domain/AppleTarget.kt
+++ b/src/main/kotlin/com/chromaticnoise/multiplatformswiftpackage/domain/AppleTarget.kt
@@ -2,9 +2,7 @@ package com.chromaticnoise.multiplatformswiftpackage.domain
 
 import org.jetbrains.kotlin.gradle.plugin.KotlinTarget
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
-import org.jetbrains.kotlin.gradle.plugin.mpp.NativeBinary
 import org.jetbrains.kotlin.gradle.plugin.mpp.NativeOutputKind
-import java.io.File
 
 internal class AppleTarget private constructor(val nativeTarget: KotlinNativeTarget) {
 

--- a/src/main/kotlin/com/chromaticnoise/multiplatformswiftpackage/domain/extensions.kt
+++ b/src/main/kotlin/com/chromaticnoise/multiplatformswiftpackage/domain/extensions.kt
@@ -1,13 +1,7 @@
 package com.chromaticnoise.multiplatformswiftpackage.domain
 
-import org.gradle.api.Action
 import org.jetbrains.kotlin.konan.target.Family
 import org.jetbrains.kotlin.konan.target.KonanTarget
-
-internal fun <T> Action<T>.build(dsl: T, builder: (dsl: T) -> Unit) {
-    execute(dsl)
-    builder(dsl)
-}
 
 internal val Family.swiftPackagePlatformName get() = when (this) {
     Family.OSX -> "macOS"

--- a/src/test/kotlin/com/chromaticnoise/multiplatformswiftpackage/dsl/TargetPlatformDslTest.kt
+++ b/src/test/kotlin/com/chromaticnoise/multiplatformswiftpackage/dsl/TargetPlatformDslTest.kt
@@ -11,64 +11,63 @@ import io.kotest.property.Arb
 import io.kotest.property.arbitrary.filter
 import io.kotest.property.arbitrary.string
 import io.kotest.property.forAll
-import org.gradle.api.Action
 
 class TargetPlatformDslTest : StringSpec() {
 
     init {
         "adding ios targets should add arm 64 target" {
-            TargetPlatformDsl().apply { iOS(someVersion()) }.targetPlatforms
+            TargetPlatformDsl().apply { iOS(someVersion) }.targetPlatforms
                 .shouldHaveTarget("iosArm64")
         }
 
         "adding ios targets should add x64 target" {
-            TargetPlatformDsl().apply { iOS(someVersion()) }.targetPlatforms
+            TargetPlatformDsl().apply { iOS(someVersion) }.targetPlatforms
                 .shouldHaveTarget("iosX64")
         }
 
         "adding watchOS targets should add arm 32 target" {
-            TargetPlatformDsl().apply { watchOS(someVersion()) }.targetPlatforms
+            TargetPlatformDsl().apply { watchOS(someVersion) }.targetPlatforms
                 .shouldHaveTarget("watchosArm32")
         }
 
         "adding watchOS targets should add arm 64 target" {
-            TargetPlatformDsl().apply { watchOS(someVersion()) }.targetPlatforms
+            TargetPlatformDsl().apply { watchOS(someVersion) }.targetPlatforms
                 .shouldHaveTarget("watchosArm64")
         }
 
         "adding watchOS targets should add x86 target" {
-            TargetPlatformDsl().apply { watchOS(someVersion()) }.targetPlatforms
+            TargetPlatformDsl().apply { watchOS(someVersion) }.targetPlatforms
                 .shouldHaveTarget("watchosX86")
         }
 
         "adding tvOS targets should add arm 64 target" {
-            TargetPlatformDsl().apply { tvOS(someVersion()) }.targetPlatforms
+            TargetPlatformDsl().apply { tvOS(someVersion) }.targetPlatforms
                 .shouldHaveTarget("tvosArm64")
         }
 
         "adding tvOS targets should add x64 target" {
-            TargetPlatformDsl().apply { tvOS(someVersion()) }.targetPlatforms
+            TargetPlatformDsl().apply { tvOS(someVersion) }.targetPlatforms
                 .shouldHaveTarget("tvosX64")
         }
 
         "adding macOS targets should add x64 target" {
-            TargetPlatformDsl().apply { macOS(someVersion()) }.targetPlatforms
+            TargetPlatformDsl().apply { macOS(someVersion) }.targetPlatforms
                 .shouldHaveTarget("macosX64")
         }
 
         "adding target without names should not add a platform target" {
-            TargetPlatformDsl().apply { targets(version = someVersion()) }.targetPlatforms
+            TargetPlatformDsl().apply { targets(version = someVersion) }.targetPlatforms
                 .shouldBeEmpty()
         }
 
         "adding target with empty name should add an invalid-name error" {
-            TargetPlatformDsl().apply { targets("", version = someVersion()) }.targetPlatforms
+            TargetPlatformDsl().apply { targets("", version = someVersion) }.targetPlatforms
                 .shouldHaveError(InvalidTargetName(""))
         }
 
         "adding target with blank name should add an invalid-name error" {
             forAll(Arb.string().filter { it.isBlank() }) { name ->
-                TargetPlatformDsl().apply { targets(name, version = someVersion()) }.targetPlatforms.errors.firstOrNull {
+                TargetPlatformDsl().apply { targets(name, version = someVersion) }.targetPlatforms.errors.firstOrNull {
                     it == InvalidTargetName(name)
                 } != null
             }
@@ -76,29 +75,20 @@ class TargetPlatformDslTest : StringSpec() {
 
         "adding target with unknown name should add an invalid-name error" {
             forAll(Arb.string().filter { TargetName.of(it) == null }) { name ->
-                TargetPlatformDsl().apply { targets(name, version = someVersion()) }.targetPlatforms.errors.firstOrNull {
+                TargetPlatformDsl().apply { targets(name, version = someVersion) }.targetPlatforms.errors.firstOrNull {
                     it == InvalidTargetName(name)
                 } != null
             }
         }
 
         "adding target with invalid version should not add a platform target" {
-            TargetPlatformDsl().apply { targets("target", version = invalidVersion()) }.targetPlatforms
+            TargetPlatformDsl().apply { targets("target", version = invalidVersion) }.targetPlatforms
                 .shouldBeEmpty()
         }
     }
 
-    private fun someVersion() = object : Action<PlatformVersionDsl> {
-        override fun execute(t: PlatformVersionDsl) {
-            t.v("13")
-        }
-    }
-
-    private fun invalidVersion() = object : Action<PlatformVersionDsl> {
-        override fun execute(t: PlatformVersionDsl) {
-            t.v("")
-        }
-    }
+    private val someVersion: (PlatformVersionDsl) -> Unit = { it.v("13") }
+    private val invalidVersion: (PlatformVersionDsl) -> Unit = { it.v("") }
 
     private fun Collection<Either<List<PluginConfigurationError>, TargetPlatform>>.shouldHaveTarget(name: String) =
         platforms.firstOrNull {


### PR DESCRIPTION
The plugin DSL was not compatible with Groovy because (1) nested
lambdas were executed in the wrong receiver scope and because
(2) Groovy functions do not support vararg and trailing closure
at the same time.

To resolve the first issue uses of the `Action<>` interface were replaced
with closures with receiver instead. Also, an overload for each public
function that accepts a closure as an argument was added, where instead
of the lambda the Groovy `Closure<>` type is used.

The second issue is fixed by adding an overload that accepts a list instead
of a vararg.